### PR TITLE
Feature/trip 비정기 PR

### DIFF
--- a/src/app/(providers)/(authenticated)/chat/layout.tsx
+++ b/src/app/(providers)/(authenticated)/chat/layout.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = defaultMetaData;
 
 const ChatPageLayout: React.FC<ChatPageLayoutProps> = ({ children }) => {
     return (
-        <div className="xl:flex">
+        <div className="xl:flex xl:justify-center">
             <div className="hidden xl:block xl:w-1/3">
                 <ChatLayoutHeader />
                 <ChatList />

--- a/src/components/atoms/common/TapMenuButton.tsx
+++ b/src/components/atoms/common/TapMenuButton.tsx
@@ -10,6 +10,7 @@ import { usePathname } from 'next/navigation';
 import { twMerge } from 'tailwind-merge';
 import useChatStore from '@/zustand/chat.store';
 import UnreadMessages from '../chatpage/UnreadMessages';
+import { useUnreadMessagesContext } from '@/contexts/unreadMessages.context';
 interface TapMenuButtonProps {
     iconName: string;
     href: string;
@@ -23,7 +24,11 @@ const TapMenuButton: React.FC<TapMenuButtonProps> = ({
 }) => {
     const pathname = usePathname();
 
-    const totalUnreadCount = useChatStore(state => state.getTotalUnreadCount());
+    // const totalUnreadCount = useChatStore(state => state.getTotalUnreadCount());
+
+    const { allUnreadCounts } = useUnreadMessagesContext();
+
+    // const totalUnreadCount = contractUnreadCounts[contract_trip_id];
 
     return (
         <Link href={href}>
@@ -68,9 +73,9 @@ const TapMenuButton: React.FC<TapMenuButtonProps> = ({
                         )}
                     />
                 )}
-                {iconName === 'Chat' && totalUnreadCount > 0 && (
+                {iconName === 'Chat' && allUnreadCounts > 0 && (
                     <div className="absolute top-[4px] right-[14px] z-100">
-                        <UnreadMessages unread_count={totalUnreadCount} />
+                        <UnreadMessages unread_count={allUnreadCounts} />
                     </div>
                 )}
                 <span

--- a/src/components/molecules/chatpage/ChatListItem.tsx
+++ b/src/components/molecules/chatpage/ChatListItem.tsx
@@ -35,7 +35,7 @@ const ChatListItem: React.FC<ContractData> = ({
                         alt="Profile"
                         width={23}
                         height={23}
-                        className="object-cover"
+                        className="object-cover w-auto h-auto"
                     />
                 )}
             </div>

--- a/src/components/molecules/chatpage/ChatMessageList.tsx
+++ b/src/components/molecules/chatpage/ChatMessageList.tsx
@@ -118,7 +118,11 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({
                                 await supabase
                                     .from('contract')
                                     .select('contract_id')
-                                    .eq('contract_trip_id', id);
+                                    .eq('contract_trip_id', id)
+                                    .eq(
+                                        'contract_buddy_id',
+                                        currentBuddy?.buddy_id,
+                                    );
 
                             if (contractsError) {
                                 console.error(

--- a/src/components/molecules/common/Header.tsx
+++ b/src/components/molecules/common/Header.tsx
@@ -4,14 +4,14 @@ import Link from 'next/link';
 import HeaderMyPageLink from '../../atoms/common/HeaderMyPageLink';
 import { twMerge } from 'tailwind-merge';
 import { usePathname } from 'next/navigation';
-import useChatStore from '@/zustand/chat.store';
 import UnreadMessages from '../../atoms/chatpage/UnreadMessages';
-import { relative } from 'path';
+import { useUnreadMessagesContext } from '@/contexts/unreadMessages.context';
 
 export default function Header() {
     const pathname = usePathname();
 
-    const totalUnreadCount = useChatStore(state => state.getTotalUnreadCount());
+    // const totalUnreadCount = useChatStore(state => state.getTotalUnreadCount());\
+    const { allUnreadCounts } = useUnreadMessagesContext();
 
     return (
         <header
@@ -64,10 +64,10 @@ export default function Header() {
                             `}
                         >
                             여정채팅
-                            {totalUnreadCount > 0 && (
+                            {allUnreadCounts > 0 && (
                                 <div className="absolute top-[-2px] right-[-28px] z-100 scale-[0.8]">
                                     <UnreadMessages
-                                        unread_count={totalUnreadCount}
+                                        unread_count={allUnreadCounts}
                                     />
                                 </div>
                             )}

--- a/src/components/molecules/stories/StoryCard.tsx
+++ b/src/components/molecules/stories/StoryCard.tsx
@@ -10,7 +10,7 @@ import {
 import { getTimeSinceUpload } from '@/utils/common/getTimeSinceUpload';
 import Image from 'next/image';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import React from 'react';
 import { twMerge } from 'tailwind-merge';
 
@@ -32,6 +32,7 @@ const StoryCard: React.FC<StoryCardProps> = ({
     isMain = false,
 }) => {
     const pathname = usePathname();
+    const router = useRouter();
 
     return (
         <div
@@ -79,6 +80,9 @@ const StoryCard: React.FC<StoryCardProps> = ({
                     fill
                     sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
                     className="rounded-full object-cover"
+                    onClick={() =>
+                        router.push(`/profile/${story.buddies.buddy_id}`)
+                    }
                 />
                 {mode === 'my' && <AddButtonSmall />}
             </div>

--- a/src/components/organisms/homepage/HomePageContainer.tsx
+++ b/src/components/organisms/homepage/HomePageContainer.tsx
@@ -42,21 +42,23 @@ const HomePageContainer = () => {
     // if (queries.some(query => query.isPending)) return <DefaultLoader />;
 
     return (
-        <div className="rounded-t-[32px] bg-white px-5 py-4 z-10 relative">
+        <div className="rounded-t-[32px] bg-white px-5 pt-4 pb-0 z-10 relative">
             <HomePageSearchBar />
-            <div className="mt-4 mb-2 relative z-10">
+            <div className="mt-12 pb-2 relative z-10 min-h-[200px] h-[200px]">
                 <HomePageTitle
+                    className="relative mt-0 mb-0 h-[40%]"
                     title="추천 인기 버디즈"
                     buttonText="전체보기"
                     description="버디즈에게 가장 인기있는 버디즈예요!"
                     href="/rank"
                 />
                 <div
-                    className="overflow-x-scroll scrollbar-hidden flex gap-[10px]"
+                    className="relative overflow-x-scroll scrollbar-hidden flex gap-[10px] h-[60%]"
                     ref={buddiesRef}
                 >
                     {buddies.data?.buddies && (
                         <HomePageRecommendBuddiesList
+                            className="min-w-[243px] mx-0 border-none shadow-lg"
                             buddies={buddies.data?.buddies}
                         />
                     )}
@@ -82,6 +84,7 @@ const HomePageContainer = () => {
                     title="인기 스토리"
                     buttonText="전체보기"
                     description="버디즈의 스토리를 확인하세요!"
+                    className="mt-0"
                     href="/stories"
                 />
                 <div
@@ -109,15 +112,16 @@ const HomePageContainer = () => {
                 )}
             </div>
 
-            <div className="mt-4 mb-5 relative z-10 h-fit">
+            <div className="mt-12 mb-0 relative z-10 min-h-[300px] h-[320px]">
                 <HomePageTitle
                     title="지금 모집중인 여정"
                     buttonText="전체보기"
                     description="함께 여행할 버디즈를 찾아보세요!"
                     href="/trips"
+                    className="relative mt-0 mb-0 h-[25%]"
                 />
                 <div
-                    className="relative h-fit overflow-x-scroll scrollbar-hidden flex gap-[10px] min-h-[215px] px-[1px]"
+                    className="relative overflow-x-scroll scrollbar-hidden flex gap-[10px] min-h-[215px] px-[1px] h-[75%]"
                     ref={tripsRef}
                 >
                     {upcomingTrips.length > 0 && (

--- a/src/components/organisms/homepage/HomePageRecommendBuddiesList.tsx
+++ b/src/components/organisms/homepage/HomePageRecommendBuddiesList.tsx
@@ -8,6 +8,7 @@ import { getAgeFromBirthDate } from '@/utils/common/getAgeFromBirthDate';
 import { useAuth } from '@/hooks';
 import { useRouter } from 'next/navigation';
 import FollowHeartButton from '../profile/FollowHeartButton';
+import { twMerge } from 'tailwind-merge';
 
 function HomePageRecommendBuddiesList({
     buddies,
@@ -29,7 +30,10 @@ function HomePageRecommendBuddiesList({
                 ? buddies.map((buddy: Buddy, index: number) => (
                       <div
                           key={index}
-                          className={`relative h-[75px] px-2 mx-1 rounded border border-gray-200 cursor-pointer flex items-center ${className}`}
+                          className={twMerge(
+                              'relative h-[89px] px-2 mx-1 rounded-[8px] border border-gray-200 cursor-pointer flex items-center',
+                              className,
+                          )}
                           onClick={() => handleCardClick(buddy.buddy_id)}
                       >
                           <div className="flex items-center justify-center w-full h-full relative">
@@ -53,13 +57,13 @@ function HomePageRecommendBuddiesList({
                                           ? `#${buddy.buddy_preferred_buddy1} #${buddy.buddy_preferred_buddy2}`
                                           : '#태그없음'}
                                   </span>
-                                  <div className="text-m font-bold whitespace-nowrap overflow-hidden text-ellipsis w-full">
+                                  <div className="text-m font-bold whitespace-nowrap overflow-hidden text-ellipsis w-full max-w-[152px]">
                                       <span className="block truncate">
                                           {buddy.buddy_nickname}
                                           {typeof buddy.buddy_birth === 'string'
                                               ? ` / ${getAgeFromBirthDate(
                                                     buddy.buddy_birth,
-                                                )} 세`
+                                                )}세`
                                               : null}
                                       </span>
                                   </div>

--- a/src/components/organisms/trips/TripCard.tsx
+++ b/src/components/organisms/trips/TripCard.tsx
@@ -425,7 +425,7 @@ const TripCard: React.FC<TripCardProps> = ({
             {isBookMarkMutationPending && <DefaultLoader />}
             <div
                 className={clsx(
-                    'bg-white box-border shadow-xl xl:shadow-none',
+                    'bg-white box-border shadow-xl xl:shadow-md',
                     mode === 'detail' && 'h-fit p-4 xl:w-[60%]',
                     mode === 'list' && 'w-[90%] h-fit rounded-lg xl:w-full',
                     mode === 'card' &&


### PR DESCRIPTION
## PR 전 체크리스트

- [x] : Commit 상세히 남겼는지 확인하기 (아닌 것 같다면 PR 작업 내용에 상세히 남기기)
- [x] : `yarn build`로 빌드 에러나는 것이 없는지 확인하기

## 작업 내용

- 모바일탭메뉴와 데스크탑 헤더에서도 메시지 읽음 개수가 정확히 표시되도록 수정
- 메인 페이지에서 프로필 카드가 디자인 시안과 일치하도록 수정

## 기술적 의사 결정 사유

- 메시지 읽음 개수가 정확히 표시 되지 않던 이유는 zustand 스토어에서의 액션이 정상적으로 작동하지 않았기 때문이었습니다.
- 이 부분을 그냥 zustand 대신 context api 로 처리했습니다.
- 또한 ChatMessageList.tsx 에서 isPageVisible 일때 contract 를 셀렉트하는 조건에 `eq('contract_buddy_id',currentBuddy?.buddy_id)` 구문이 없었습니다.
- 스타일의 경우는, 메인 페이지에서 추천버디즈 목록이 디자인시안과 일치하지 않아 일치시켰습니다.
