### PR TITLE
[style]: 데스크탑에서 여정 생성시 지역 선택 오버플로우 문제 해결

### DIFF
--- a/src/components/atoms/onboarding/OnBoardinginnerWrapper.tsx
+++ b/src/components/atoms/onboarding/OnBoardinginnerWrapper.tsx
@@ -30,7 +30,7 @@ const OnBoardingInnerWrapper = ({
                     {
                         'justify-start': align === 'start',
                         'justify-end': align === 'end',
-                        'justify-center': align === 'center',
+                        'justify-center xl:justify-start': align === 'center',
                     },
                 ),
                 className,

--- a/src/components/molecules/common/SelectRegion.tsx
+++ b/src/components/molecules/common/SelectRegion.tsx
@@ -62,7 +62,7 @@ const SelectRegions = forwardRef<HTMLElement, SelectRegionProps>(
                 {/* 도시/대륙 선택 */}
                 <section
                     className={twMerge(
-                        'overflow-x-scroll scrollbar-hidden flex gap-[10px] xl:h-[10%] xl:pb-6',
+                        'overflow-x-scroll scrollbar-hidden flex gap-[10px] xl:h-[10%] xl:pb-6 justify-center items-center',
                         innerHeight && innerHeight < 659 && 'h-[42px]',
                     )}
                     ref={ref}

--- a/src/components/molecules/onboarding/ThirdLevelSection.tsx
+++ b/src/components/molecules/onboarding/ThirdLevelSection.tsx
@@ -34,7 +34,7 @@ const ThirdLevelSection: React.FC<ThirdLevelSectionProps> = memo(
                         pathname === '/write' && 'h-[39vh]',
                         pathname.startsWith('/edit') && 'h-[70%] xl:h-[450px]',
                         pathname.startsWith('/onboarding') &&
-                            'h-[44vh] xl:h-[450px]',
+                            'h-[44vh] xl:h-[44vh]',
                         !secondLevelLocation &&
                             'hidden xl:flex xl:min-h-[50vh] xl:h-[50vh]',
                     )}


### PR DESCRIPTION
## PR 전 체크리스트

- [x] : Commit 상세히 남겼는지 확인하기 (아닌 것 같다면 PR 작업 내용에 상세히 남기기)
- [x] : `yarn build`로 빌드 에러나는 것이 없는지 확인하기

## 작업 내용

- 데스크탑 뷰에서 여정 생성 중 지역 선택 탭에서 목록 오버플로우 되는 문제 해결

## 기술적 의사 결정 사유

- 제발 마지막이길
