### PR TITLE
[update]: 버디 정보 바로 업데이트 안되는 문제 - 캐시 노스토어 추가

### DIFF
--- a/src/hooks/queries/buddy/useBuddyProfile.ts
+++ b/src/hooks/queries/buddy/useBuddyProfile.ts
@@ -9,6 +9,7 @@ export const fetchBuddyProfile = async (id: string) => {
             `/api/buddyProfile/buddy?id=${id}`,
             {
                 method: 'GET',
+                cache: 'no-store',
             },
         );
         return data;


### PR DESCRIPTION
## PR 전 체크리스트

- [x] : Commit 상세히 남겼는지 확인하기 (아닌 것 같다면 PR 작업 내용에 상세히 남기기)
- [x] : `yarn build`로 빌드 에러나는 것이 없는지 확인하기

## 작업 내용

- 버디정보 바로 업데이트 안되는 문제 수정

## 기술적 의사 결정 사유

- fetch 에 cache : 'no-store' 추가했습니다.
- 여러분 수고많으셨습니다 :)
